### PR TITLE
VS 2022 support.

### DIFF
--- a/OriginalBlueTheme/OriginalBlueTheme.csproj
+++ b/OriginalBlueTheme/OriginalBlueTheme.csproj
@@ -12,17 +12,15 @@
     <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProjectGuid>{4E0A477B-B5F0-418D-BF07-103262A8CA9D}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>OriginalBlueTheme</RootNamespace>
     <AssemblyName>OriginalBlueTheme</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
-    <UseCodebase>true</UseCodebase>
-    <IncludeAssemblyInVSIXContainer>true</IncludeAssemblyInVSIXContainer>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
     <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
     <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-    <CopyBuildOutputToOutputDirectory>true</CopyBuildOutputToOutputDirectory>
-    <CopyOutputSymbolsToOutputDirectory>true</CopyOutputSymbolsToOutputDirectory>
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
@@ -48,17 +46,19 @@
     <None Include="source.extension.vsixmanifest">
       <SubType>Designer</SubType>
     </None>
-    <None Include="vs2017_blue.vstheme" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="System" />
+    <None Include="vs2017_blue.vstheme" >
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.200" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.VsixColorCompiler">
       <Version>16.0.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.1.3132" />
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.0.1600">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />

--- a/OriginalBlueTheme/source.extension.vsixmanifest
+++ b/OriginalBlueTheme/source.extension.vsixmanifest
@@ -1,20 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="OriginalBlueTheme.e1e706e2-05d3-4da9-8754-652cd8ab65f4" Version="1.0" Language="en-US" Publisher="Robin Degen" />
+        <Identity Id="OriginalBlueTheme.e1e706e2-05d3-4da9-8754-652cd8ab65f4" Version="1.2" Language="en-US" Publisher="Robin Degen" />
         <DisplayName>OriginalBlueTheme</DisplayName>
         <Description xml:space="preserve">The original Blue theme from Visual Studio 2017</Description>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+        <ProductArchitecture>amd64</ProductArchitecture>
+       </InstallationTarget>
+  </Installation>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
 </PackageManifest>

--- a/OriginalBlueTheme/source.extension.vsixmanifest
+++ b/OriginalBlueTheme/source.extension.vsixmanifest
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="OriginalBlueTheme.e1e706e2-05d3-4da9-8754-652cd8ab65f4" Version="1.2" Language="en-US" Publisher="Robin Degen" />
+        <Identity Id="OriginalBlueTheme.e1e706e2-05d3-4da9-8754-652cd8ab65f4" Version="1.3" Language="en-US" Publisher="Robin Degen" />
         <DisplayName>OriginalBlueTheme</DisplayName>
         <Description xml:space="preserve">The original Blue theme from Visual Studio 2017</Description>
     </Metadata>
     <Installation>
-      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-      <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
-        <ProductArchitecture>amd64</ProductArchitecture>
-       </InstallationTarget>
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0, 18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
 </PackageManifest>

--- a/OriginalBlueTheme/vs2017_blue.vstheme
+++ b/OriginalBlueTheme/vs2017_blue.vstheme
@@ -8785,7 +8785,7 @@
     </Category>
     <Category Name="ThemedDialog" GUID="{5e04b2a9-e443-48db-8791-63a2a71cfbd7}">
       <Color Name="WindowPanel">
-        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Background Type="CT_RAW" Source="FFFBFBFB" />
         <Foreground Type="CT_RAW" Source="FF1E1E1E" />
       </Color>
       <Color Name="WindowBorder">
@@ -8807,8 +8807,8 @@
         <Background Type="CT_RAW" Source="FFA2A4A5" />
       </Color>
       <Color Name="SelectedItemActive">
-        <Background Type="CT_RAW" Source="FF007ACC" />
-        <Foreground Type="CT_RAW" Source="FFFFFFFF" />
+        <Background Type="CT_RAW" Source="FFFEFEFE" />
+        <Foreground Type="CT_RAW" Source="FF1E1E1E" />
       </Color>
       <Color Name="SelectedItemInactive">
         <Background Type="CT_RAW" Source="FFE1E1E1" />
@@ -8894,13 +8894,13 @@
         <Background Type="CT_RAW" Source="FFFF0000" />
       </Color>
       <Color Name="ActionButtonBackground">
-        <Background Type="CT_RAW" Source="FFFCFCFC" />
+        <Background Type="CT_RAW" Source="FFEEEBEB" />
       </Color>
       <Color Name="ActionButtonStroke">
-        <Background Type="CT_RAW" Source="FFFCFCFC" />
+        <Background Type="CT_RAW" Source="FFEEEBEB" />
       </Color>
       <Color Name="ActionButtonStrokeHover">
-        <Background Type="CT_RAW" Source="FFFCFCFC" />
+        <Background Type="CT_RAW" Source="FFEEEBEB" />
       </Color>
       <Color Name="ActionButtonStrokeActive">
         <Background Type="CT_RAW" Source="FF000000" />
@@ -8909,7 +8909,7 @@
         <Background Type="CT_RAW" Source="FF1E1E1E" />
       </Color>
       <Color Name="ActionButtonTextActive">
-        <Background Type="CT_RAW" Source="FFFFFFFF" />
+        <Background Type="CT_RAW" Source="FF1E1E1E" />
       </Color>
       <Color Name="StartWindowDescription">
         <Foreground Type="CT_RAW" Source="FF4F4F4F" />


### PR DESCRIPTION
Resolve https://github.com/robindegen/vs2019_original_blue_theme/issues/2.
Resolve https://github.com/robindegen/vs2019_original_blue_theme/issues/3.
Not sure about #4. What did you mean by:

> The archive is still called vs2019_...

?
 The  archive is  `OriginalBlueTheme.vsix` :man_shrugging: